### PR TITLE
Fix npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "lint": "eslint . --fix",
+    "pretest": "npm run lint",
     "start": "nodemon --exec babel-node index.js",
     "test": "ava --verbose"
   },
@@ -41,7 +43,5 @@
       "@babel/register",
       "@babel/polyfill"
     ]
-  },
-  "lint": "eslint . --fix",
-  "pretest": "npm run lint"
+  }
 }


### PR DESCRIPTION
The scripts needs to be namespaced under `scripts` in the package.json or they are not available for someone to run.